### PR TITLE
breaking API changes to useAsyncEffect

### DIFF
--- a/docs/use-async-effect.md
+++ b/docs/use-async-effect.md
@@ -6,25 +6,31 @@ Enables asynchronous effects with some guardrails to protect against memory-leak
 ## Example
 
 ```tsx
-useAsyncEffect(async (ctx) => {
-  ctx.hello = 'world'; // Attach anything you like to the context object!
-  return fetch('...').then(res => res.json());
-}, [/* effect dependencies */])
-.fulfilled((value, ctx) => {
-    // Equivalent to `Promise.then`
-    console.log(value); // Do something with your JSON!
-    console.log(ctx.hello) // => 'world'
-  })
-.rejected((reason, ctx) => {
-    // Equivalent to `Promise.catch`
-    // ...
-  })
-.settled((ctx) => {
-    // Equivalent to `Promise.finally`
-    // ...
-  })
-.cleanup((ctx) => {
-  // Defines the same behavior as a function returned by `useEffect`
-  // ...
+useAsyncEffect(() => {
+  return {
+    execute: async (signal) => {
+      return fetch('...', { signal }).then(res => res.json());
+    },
+
+    onFulfilled: (value) => {
+      // Equivalent to `Promise.then`
+      console.log(value); // Do something stateful with your JSON!
+    },
+
+    onRejected: (reason) => {
+      // Equivalent to `Promise.catch`
+      // ...
+    },
+
+    onSettled: () => {
+      // Equivalent to `Promise.finally`
+      // ...
+    },
+
+    onCleanup: () => {
+      // Defines the same behavior as a function returned by `useEffect`
+      // ...
+    },
+  }
 });
 ```

--- a/docs/use-hash.md
+++ b/docs/use-hash.md
@@ -1,6 +1,6 @@
 # `useHash`
 
-Returns an MD5-compatible hash of any value given to this hook as its argument. Most client-side structures are hashable based on their serialized contents. This is handy for translating complex objects into a primitive string value for accurately detecting updates between render ticks as a dependency given to `useEffect`.
+Returns an MD5-compliant hash of any value given to this hook as its argument. Most client-side structures are hashable based on their serialized contents. This is handy for translating complex objects into a primitive string value for accurately detecting updates between renders as a dependency provided to `useEffect`.
 
 ## Example
 


### PR DESCRIPTION
- Simplifies the API for `useAsyncEffect`.
- Adds support for `AbortSignal` in `useAsyncEffect`